### PR TITLE
README.md fix + beam_search.py fix + easier setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "res/external/sdsl-lite"]
 	path = res/external/sdsl-lite
-	url = git@github.com:simongog/sdsl-lite.git
+	url = https://github.com/simongog/sdsl-lite.git

--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ following snippet we show a use case beyond retrieval: paraphrase mining.
 from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
 from seal import fm_index_generate, FMIndex
 
-tokenizer = AutoTokenizer.from_pretrained('tuner007/pegaus_paraphrase')
-model = AutoModelForSeq2SeqLM.from_pretrained('tuner007/pegaus_paraphrase')
+tokenizer = AutoTokenizer.from_pretrained('tuner007/pegasus_paraphrase')
+model = AutoModelForSeq2SeqLM.from_pretrained('tuner007/pegasus_paraphrase')
 
 # building the corpus from a single long string
 corpus = " ".join("""

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ We also assume that `pytorch` is already available in your environment. SEAL has
 
 Clone this repo with `--recursive` so that you also include the submodule in `res/external`.
 ```commandline
-git clone --recursive git@github.com:facebookresearch/SEAL.git
+git clone --recursive https://github.com/facebookresearch/SEAL.git
 ```
 
 Compile and install `sdsl-lite`:

--- a/README.md
+++ b/README.md
@@ -29,9 +29,14 @@ from simple unigrams to entire sentences.
 Our implementation relies on [`sdsl-lite`](https://github.com/simongog/sdsl-lite).
 
 ## Install
-We assume that `pytorch` is already available in your environment. SEAL has been tested with version 1.11.
+SEAL needs a working installation of [SWIG](https://www.swig.org/), e.g. (on Ubuntu):
+```commandline
+sudo apt install swig
+```
 
-Clone this repo with `--recursive` so that you also include the submodule in `ext`.
+We also assume that `pytorch` is already available in your environment. SEAL has been tested with version 1.11.
+
+Clone this repo with `--recursive` so that you also include the submodule in `res/external`.
 ```commandline
 git clone --recursive git@github.com:facebookresearch/SEAL.git
 ```
@@ -45,7 +50,7 @@ Install other dependencies:
 ```commandline
 pip install -r requirements.txt
 
-# pyserini & spacy
+# pyserini
 # pip install -r requirements_extra.txt
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ jsonlines
 fuzzywuzzy
 more_itertools
 transformers==4.13.0
+spacy
 ftfy

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ fuzzywuzzy
 more_itertools
 transformers==4.13.0
 spacy
+psutil
 ftfy

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -1,2 +1,1 @@
 pyserini==0.13.0
-spacy

--- a/seal/beam_search.py
+++ b/seal/beam_search.py
@@ -127,6 +127,7 @@ class IndexBasedLogitsProcessor(LogitsProcessor):
                         distinct = [self.pad_token_id]
 
                     else:
+                        fm_index_counts.pop()
                         distinct, _ = fm_index_result.pop()
 
                     distinct = torch.LongTensor(distinct).to(scores.device)
@@ -482,7 +483,7 @@ def fm_index_generate(
     model_kwargs['use_cache'] = True
 
     decoder_input_ids = model._prepare_decoder_input_ids_for_generation(
-        input_ids, 
+        batch_size=input_ids.size(0),
         decoder_start_token_id=model.config.decoder_start_token_id, 
         bos_token_id=model.config.bos_token_id,
     )


### PR DESCRIPTION
- Fixed the permission problem with `--recursive` (Issue #5).
- More complete instructions for the setup.
- README.md fix (including PR #8).
- Added missing `fm_index_counts.pop()` in `seal/beam_search.py` (Issue #6). 
- Fixed problems preventing the usage of the Searcher.search (Issue #7).